### PR TITLE
Add Forum Link to Translations Across Multiple Languages

### DIFF
--- a/constants/header.ts
+++ b/constants/header.ts
@@ -22,6 +22,11 @@ export const header: HeaderLink[] = [
     newTab: true,
   },
   {
+    label: "links.forum",
+    href: links.forum,
+    newTab: true,
+  },
+  {
     label: "links.community",
     href: "/community/",
   },

--- a/locales/ar/translation.json
+++ b/locales/ar/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "التوثيق",
       "blog": "المدونة",
+      "forum": "المنتدى",
       "proposals": "المقترحات",
       "community": "المجتمع"
     }

--- a/locales/bg/translation.json
+++ b/locales/bg/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Документация",
       "blog": "Блог",
+      "forum": "Форум",
       "proposals": "Предложения",
       "community": "Общество"
     }

--- a/locales/cs/translation.json
+++ b/locales/cs/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Dokumentace",
       "blog": "Blog",
+      "forum": "Fórum",
       "proposals": "Návrhy",
       "community": "Komunita"
     }

--- a/locales/da/translation.json
+++ b/locales/da/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Dokumentation",
       "blog": "Blog",
+      "forum": "Forum",
       "proposals": "Forslag",
       "community": "Fællesskab"
     }

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Dokumentation",
       "blog": "Blog",
+      "forum": "Forum",
       "proposals": "Vorschläge",
       "community": "Gemeinschaft"
     }

--- a/locales/el/translation.json
+++ b/locales/el/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Τεκμηρίωση",
       "blog": "Blog",
+      "forum": "Φόρουμ",
       "proposals": "Προτάσεις",
       "community": "Κοινότητα"
     }

--- a/locales/en-GB/translation.json
+++ b/locales/en-GB/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Documentation",
       "blog": "Blog",
+      "forum": "Forum",
       "proposals": "Proposals",
       "community": "Community"
     }

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Documentation",
       "blog": "Blog",
+      "forum": "Forum",
       "proposals": "Proposals",
       "community": "Community"
     }

--- a/locales/es-LA/translation.json
+++ b/locales/es-LA/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Documentación",
       "blog": "Blog",
+      "forum": "Foro",
       "proposals": "Propuestas",
       "community": "Comunidad"
     }

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Documentación",
       "blog": "Blog",
+      "forum": "Foro",
       "proposals": "Propuestas",
       "community": "Comunidad"
     }

--- a/locales/fi/translation.json
+++ b/locales/fi/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Dokumentaatio",
       "blog": "Blogi",
+      "forum": "Foorumi",
       "proposals": "Ehdotukset",
       "community": "Yhteisö"
     }

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Documentation",
       "blog": "Blog",
+      "forum": "Forum",
       "proposals": "Propositions",
       "community": "Communauté"
     }

--- a/locales/hi/translation.json
+++ b/locales/hi/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "दस्तावेज़",
       "blog": "ब्लॉग",
+      "forum": "फोरम",
       "proposals": "प्रस्ताव",
       "community": "समुदाय"
     }

--- a/locales/hr/translation.json
+++ b/locales/hr/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Dokumentacija",
       "blog": "Blog",
+      "forum": "Forum",
       "proposals": "Prijedlozi",
       "community": "Zajednica"
     }

--- a/locales/hu/translation.json
+++ b/locales/hu/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Dokumentáció",
       "blog": "Blog",
+      "forum": "Fórum",
       "proposals": "Javaslatok",
       "community": "Közösség"
     }

--- a/locales/it/translation.json
+++ b/locales/it/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Documentazione",
       "blog": "Blog",
+      "forum": "Forum",
       "proposals": "Proposte",
       "community": "Community"
     }

--- a/locales/ja/translation.json
+++ b/locales/ja/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "ドキュメント",
       "blog": "ブログ",
+      "forum": "フォーラム",
       "proposals": "提案",
       "community": "コミュニティ"
     }

--- a/locales/ko/translation.json
+++ b/locales/ko/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "문서",
       "blog": "블로그",
+      "forum": "포럼",
       "proposals": "제안",
       "community": "커뮤니티"
     }

--- a/locales/lt/translation.json
+++ b/locales/lt/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Dokumentacija",
       "blog": "Blogas",
+      "forum": "Forumas",
       "proposals": "Pasiūlymai",
       "community": "Bendruomenė"
     }

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Documentatie",
       "blog": "Blog",
+      "forum": "Forum",
       "proposals": "Voorstellen",
       "community": "Gemeenschap"
     }

--- a/locales/no/translation.json
+++ b/locales/no/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Dokumentasjon",
       "blog": "Blogg",
+      "forum": "Forum",
       "proposals": "Forslag",
       "community": "Samfunn"
     }

--- a/locales/pl/translation.json
+++ b/locales/pl/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Dokumentacja",
       "blog": "Blog",
+      "forum": "Forum",
       "proposals": "Oferty",
       "community": "Społeczność"
     }

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Documentação",
       "blog": "Blog",
+      "forum": "Fórum",
       "proposals": "Propostas",
       "community": "Comunidade"
     }

--- a/locales/ro/translation.json
+++ b/locales/ro/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Documentație",
       "blog": "Blog",
+      "forum": "Forum",
       "proposals": "Proiecte",
       "community": "Comunitate"
     }

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Документация",
       "blog": "Блог",
+      "forum": "Форум",
       "proposals": "Предложения",
       "community": "Сообщество"
     }

--- a/locales/sv/translation.json
+++ b/locales/sv/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Dokumentation",
       "blog": "Blogg",
+      "forum": "Forum",
       "proposals": "Förslag",
       "community": "Community"
     }

--- a/locales/th/translation.json
+++ b/locales/th/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "เอกสาร",
       "blog": "บล็อก",
+      "forum": "ฟอรัม",
       "proposals": "ข้อเสนอ",
       "community": "ชุมชน"
     }

--- a/locales/tr/translation.json
+++ b/locales/tr/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Dokümantasyon",
       "blog": "Blog",
+      "forum": "Forum",
       "proposals": "Öneriler",
       "community": "Topluluk"
     }

--- a/locales/uk/translation.json
+++ b/locales/uk/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Документація",
       "blog": "Блог",
+      "forum": "Форум",
       "proposals": "Пропозиції",
       "community": "Спільнота"
     }

--- a/locales/vi/translation.json
+++ b/locales/vi/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "Tài liệu",
       "blog": "Blog",
+      "forum": "Diễn đàn",
       "proposals": "Đề xuất",
       "community": "Cộng đồng"
     }

--- a/locales/zh-Hans/translation.json
+++ b/locales/zh-Hans/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "文档",
       "blog": "博客",
+      "forum": "论坛",
       "proposals": "提案",
       "community": "社区"
     }

--- a/locales/zh-TW/translation.json
+++ b/locales/zh-TW/translation.json
@@ -9,6 +9,7 @@
     "links": {
       "documentation": "文件",
       "blog": "部落格",
+      "forum": "論壇",
       "proposals": "提案",
       "community": "社群"
     }


### PR DESCRIPTION
**PR Content:**
This commit adds a link to the forum in the header, ensuring it's included in multiple language translations. The new link points to the appropriate forum section and opens in a new tab.