### PR TITLE
 Update Package Ecosystem from npm to Bun in Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,10 @@
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
**PR Content:**
This update modifies the Dependabot configuration to use Bun as the package ecosystem instead of npm.
<!-- Any other information or context that might be helpful for the maintainers. -->
