### PR TITLE
Enable Beta Ecosystems in Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` file to enable beta ecosystems for Dependabot. 